### PR TITLE
Initial gNOI Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ $(TELEMETRY_TEST_BIN): $(TEST_FILES) $(SRC_FILES)
 	GOPATH=$(GOPATH) $(GO) test -c -cover gnmi_server -o $@
 	cp -r src/testdata $(TELEMETRY_TEST_DIR)
 	cp test/01_create_MyACL1_MyACL2.json $(TELEMETRY_TEST_DIR)
-	cp -r $(GO_MGMT_PATH)/src/cvl/schema $(TELEMETRY_TEST_DIR)
+	cp -r $(GO_MGMT_PATH)/debian/sonic-mgmt-framework/usr/sbin/schema $(TELEMETRY_TEST_DIR)
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ $(BUILD_DIR)/.deps:
 	GOPATH=$(GO_DEP_PATH) $(GO) get -u github.com/xeipuuv/gojsonschema
 	GOPATH=$(GO_DEP_PATH) $(GO) get -u github.com/openconfig/gnoi/system
 
-telemetry:$(BUILD_DIR)/telemetry $(BUILD_DIR)/dialout_client_cli $(BUILD_DIR)/gnmi_get $(BUILD_DIR)/gnmi_set $(BUILD_DIR)/gnmi_cli
+telemetry:$(BUILD_DIR)/telemetry $(BUILD_DIR)/dialout_client_cli $(BUILD_DIR)/gnmi_get $(BUILD_DIR)/gnmi_set $(BUILD_DIR)/gnmi_cli $(BUILD_DIR)/gnoi_client
 
 $(BUILD_DIR)/telemetry:src/telemetry/telemetry.go
 	@echo "Building $@"
@@ -66,6 +66,8 @@ $(BUILD_DIR)/gnmi_set:src/gnmi_clients/gnmi_set.go
 	GOPATH=$(GOPATH) $(GO) build $(GOFLAGS) -o $@ $^
 $(BUILD_DIR)/gnmi_cli:src/gnmi_clients/src/github.com/openconfig/gnmi
 	GOPATH=$(PWD)/src/gnmi_clients:$(GOPATH) $(GO) build $(GOFLAGS) -o $@ github.com/openconfig/gnmi/cmd/gnmi_cli
+$(BUILD_DIR)/gnoi_client:src/gnmi_clients/gnoi_client.go
+	GOPATH=$(PWD)/src/gnmi_clients:$(GOPATH) $(GO) build $(GOFLAGS) -o $@ $^
 
 clean:
 	rm -rf $(BUILD_DIR)/telemetry
@@ -91,6 +93,7 @@ install:
 	$(INSTALL) -D $(BUILD_DIR)/gnmi_get $(DESTDIR)/usr/sbin/gnmi_get
 	$(INSTALL) -D $(BUILD_DIR)/gnmi_set $(DESTDIR)/usr/sbin/gnmi_set
 	$(INSTALL) -D $(BUILD_DIR)/gnmi_cli $(DESTDIR)/usr/sbin/gnmi_cli
+	$(INSTALL) -D $(BUILD_DIR)/gnoi_client $(DESTDIR)/usr/sbin/gnoi_client
 
 	mkdir -p $(DESTDIR)/usr/bin/
 	cp -r $(GO_MGMT_PATH)/debian/sonic-mgmt-framework/usr/sbin/schema $(DESTDIR)/usr/sbin
@@ -102,3 +105,4 @@ deinstall:
 	rm $(DESTDIR)/usr/sbin/dialout_client_cli
 	rm $(DESTDIR)/usr/sbin/gnmi_get
 	rm $(DESTDIR)/usr/sbin/gnmi_set
+	rm $(DESTDIR)/usr/sbin/gnoi_client

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ $(BUILD_DIR)/.deps:
 	GOPATH=$(GO_DEP_PATH) $(GO) get -u github.com/jipanyang/gnxi/utils/xpath
 	GOPATH=$(GO_DEP_PATH) $(GO) get -u github.com/jipanyang/gnmi/client/gnmi
 	GOPATH=$(GO_DEP_PATH) $(GO) get -u github.com/xeipuuv/gojsonschema
+	GOPATH=$(GO_DEP_PATH) $(GO) get -u github.com/openconfig/gnoi/system
 
 telemetry:$(BUILD_DIR)/telemetry $(BUILD_DIR)/dialout_client_cli $(BUILD_DIR)/gnmi_get $(BUILD_DIR)/gnmi_set $(BUILD_DIR)/gnmi_cli
 

--- a/src/gnmi_clients/gnoi_client.go
+++ b/src/gnmi_clients/gnoi_client.go
@@ -11,9 +11,16 @@ import (
 	"os"
 	"os/signal"
 	"fmt"
+	"flag"
+)
+
+var (
+	module = flag.String("module", "System", "gNOI Module")
+	rpc = flag.String("rpc", "Time", "rpc call in specified module to call")
 )
 
 func main() {
+	flag.Parse()
 	serverAddr := "localhost:8080"
 	tls_conf := tls.Config{InsecureSkipVerify: true}
     opts := []grpc.DialOption{
@@ -35,8 +42,19 @@ func main() {
 		panic(err.Error())
 	}
 	sc := gnoi_system_pb.NewSystemClient(conn)
-	tr := new(gnoi_system_pb.TimeRequest)
-	resp,err := sc.Time(ctx, tr)
+
+	switch *module {
+	case "System":
+		switch *rpc {
+		case "Time":
+			systemTime(sc, ctx)
+		}
+	}
+}
+
+func systemTime(sc gnoi_system_pb.SystemClient, ctx context.Context) {
+	fmt.Println("System Time")
+	resp,err := sc.Time(ctx, new(gnoi_system_pb.TimeRequest))
 	if err != nil {
 		panic(err.Error())
 	}

--- a/src/gnmi_clients/gnoi_client.go
+++ b/src/gnmi_clients/gnoi_client.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	gnoi_system_pb "github.com/openconfig/gnoi/system"
+	"time"
+	"math"
+	"crypto/tls"
+	"context"
+	"os"
+	"os/signal"
+	"fmt"
+)
+
+func main() {
+	serverAddr := "localhost:8080"
+	tls_conf := tls.Config{InsecureSkipVerify: true}
+    opts := []grpc.DialOption{
+            grpc.WithTimeout(time.Second * 3),
+            grpc.WithBlock(),
+            grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
+            grpc.WithTransportCredentials(credentials.NewTLS(&tls_conf)),
+    }
+
+    ctx, cancel := context.WithCancel(context.Background())
+    go func() {
+            c := make(chan os.Signal, 1)
+            signal.Notify(c, os.Interrupt)
+            <-c
+            cancel()
+    }()
+	conn, err := grpc.Dial(serverAddr, opts...)
+	if err != nil {
+		panic(err.Error())
+	}
+	sc := gnoi_system_pb.NewSystemClient(conn)
+	tr := new(gnoi_system_pb.TimeRequest)
+	resp,err := sc.Time(ctx, tr)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(resp.Time)
+}

--- a/src/gnmi_clients/gnoi_client.go
+++ b/src/gnmi_clients/gnoi_client.go
@@ -17,11 +17,11 @@ import (
 var (
 	module = flag.String("module", "System", "gNOI Module")
 	rpc = flag.String("rpc", "Time", "rpc call in specified module to call")
+	target = flag.String("target", "localhost:8080", "Address:port of gNOI Server")
 )
 
 func main() {
 	flag.Parse()
-	serverAddr := "localhost:8080"
 	tls_conf := tls.Config{InsecureSkipVerify: true}
     opts := []grpc.DialOption{
             grpc.WithTimeout(time.Second * 3),
@@ -37,7 +37,7 @@ func main() {
             <-c
             cancel()
     }()
-	conn, err := grpc.Dial(serverAddr, opts...)
+	conn, err := grpc.Dial(*target, opts...)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/src/gnmi_server/gnoi.go
+++ b/src/gnmi_server/gnoi.go
@@ -1,0 +1,44 @@
+package gnmi_server
+
+import (
+	"context"
+	gnoi_system_pb "github.com/openconfig/gnoi/system"
+	log "github.com/golang/glog"
+	"time"
+)
+
+func (srv *Server) Reboot(context.Context, *gnoi_system_pb.RebootRequest) (*gnoi_system_pb.RebootResponse, error) {
+	log.V(1).Info("gNOI: Reboot")
+	return nil, nil
+}
+func (srv *Server) RebootStatus(context.Context, *gnoi_system_pb.RebootStatusRequest) (*gnoi_system_pb.RebootStatusResponse, error) {
+	log.V(1).Info("gNOI: RebootStatus")
+	return nil, nil
+}
+func (srv *Server) CancelReboot(context.Context, *gnoi_system_pb.CancelRebootRequest) (*gnoi_system_pb.CancelRebootResponse, error) {
+	log.V(1).Info("gNOI: CancelReboot")
+	return nil, nil
+}
+func (srv *Server) Ping(*gnoi_system_pb.PingRequest, gnoi_system_pb.System_PingServer) error {
+	log.V(1).Info("gNOI: Ping")
+	return nil
+}
+func (srv *Server) Traceroute(*gnoi_system_pb.TracerouteRequest, gnoi_system_pb.System_TracerouteServer) error {
+	log.V(1).Info("gNOI: Traceroute")
+	return nil
+}
+func (srv *Server) SetPackage(gnoi_system_pb.System_SetPackageServer) error {
+	log.V(1).Info("gNOI: SetPackage")
+	return nil
+}
+func (srv *Server) SwitchControlProcessor(context.Context, *gnoi_system_pb.SwitchControlProcessorRequest) (*gnoi_system_pb.SwitchControlProcessorResponse, error) {
+	log.V(1).Info("gNOI: SwitchControlProcessor")
+	return nil, nil
+}
+func (srv *Server) Time(context.Context, *gnoi_system_pb.TimeRequest) (*gnoi_system_pb.TimeResponse, error) {
+	log.V(1).Info("gNOI: Time")
+	var tm gnoi_system_pb.TimeResponse
+	tm.Time = uint64(time.Now().UnixNano())
+	return &tm, nil
+}
+

--- a/src/gnmi_server/server.go
+++ b/src/gnmi_server/server.go
@@ -14,9 +14,10 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
-
+	gnoi_system_pb "github.com/openconfig/gnoi/system"
 	sdc "sonic_data_client"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	
 )
 
 var (
@@ -48,6 +49,7 @@ func NewServer(config *Config, opts []grpc.ServerOption) (*Server, error) {
 	}
 
 	s := grpc.NewServer(opts...)
+
 	reflection.Register(s)
 
 	srv := &Server{
@@ -64,7 +66,9 @@ func NewServer(config *Config, opts []grpc.ServerOption) (*Server, error) {
 		return nil, fmt.Errorf("failed to open listener port %d: %v", srv.config.Port, err)
 	}
 	gnmipb.RegisterGNMIServer(srv.s, srv)
+	gnoi_system_pb.RegisterSystemServer(srv.s, srv)
 	log.V(1).Infof("Created Server on %s", srv.Address())
+
 	return srv, nil
 }
 
@@ -87,7 +91,9 @@ func (srv *Server) Address() string {
 func (srv *Server) Port() int64 {
 	return srv.config.Port
 }
+// func (srv *Server) Time(stream gnmipb.GNMI_SubscribeServer) error {
 
+// }
 // Subscribe implements the gNMI Subscribe RPC.
 func (srv *Server) Subscribe(stream gnmipb.GNMI_SubscribeServer) error {
 	ctx := stream.Context()

--- a/src/gnmi_server/server.go
+++ b/src/gnmi_server/server.go
@@ -91,9 +91,7 @@ func (srv *Server) Address() string {
 func (srv *Server) Port() int64 {
 	return srv.config.Port
 }
-// func (srv *Server) Time(stream gnmipb.GNMI_SubscribeServer) error {
 
-// }
 // Subscribe implements the gNMI Subscribe RPC.
 func (srv *Server) Subscribe(stream gnmipb.GNMI_SubscribeServer) error {
 	ctx := stream.Context()


### PR DESCRIPTION
This adds a new file that registers the system gNOI module to the existing gRPC server. This is mainly an example on how to add more modules and rpcs in the future. I have only implemented a single rpc so far, the System Time rpc. I also added a simple gNOI client that allows you to call the System Time rpc and is extensible so we can add more rpcs as they are added to the server.