### PR TITLE
Snc 3791

### DIFF
--- a/src/gnmi_server/basicAuth.go
+++ b/src/gnmi_server/basicAuth.go
@@ -1,12 +1,12 @@
 package gnmi_server
 
 import (
-	"golang.org/x/net/context"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"github.com/golang/glog"
 	"common_utils"
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 func BasicAuthenAndAuthor(ctx context.Context) (context.Context, error) {
@@ -15,28 +15,28 @@ func BasicAuthenAndAuthor(ctx context.Context) (context.Context, error) {
 	if !ok {
 		return ctx, status.Errorf(codes.Unknown, "Invalid context")
 	}
-	
+
 	var username string
 	var passwd string
 	if username_a, ok := md["username"]; ok {
 		username = username_a[0]
-	}else {
+	} else {
 		return ctx, status.Errorf(codes.Unauthenticated, "No Username Provided")
 	}
 
 	if passwd_a, ok := md["password"]; ok {
 		passwd = passwd_a[0]
-	}else {
+	} else {
 		return ctx, status.Errorf(codes.Unauthenticated, "No Password Provided")
 	}
-	if err := PopulateAuthStruct(username, &rc.Auth); err != nil {
+	if err := PopulateAuthStruct(username, &rc.Auth, nil); err != nil {
 		glog.Infof("[%s] Failed to retrieve authentication information; %v", rc.ID, err)
-		return ctx, status.Errorf(codes.Unauthenticated, "")	
+		return ctx, status.Errorf(codes.Unauthenticated, "")
 	}
 	auth_success, _ := UserPwAuth(username, passwd)
 	if auth_success == false {
-		return ctx, status.Errorf(codes.PermissionDenied, "Invalid Password")	
+		return ctx, status.Errorf(codes.PermissionDenied, "Invalid Password")
 	}
-	
+
 	return ctx, nil
 }

--- a/src/gnmi_server/clientCertAuth.go
+++ b/src/gnmi_server/clientCertAuth.go
@@ -1,40 +1,40 @@
-
 package gnmi_server
 
 import (
-	"google.golang.org/grpc/peer"
+	"common_utils"
+	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-	"common_utils"
-	"github.com/golang/glog"
 )
+
 func ClientCertAuthenAndAuthor(ctx context.Context) (context.Context, error) {
 	rc, ctx := common_utils.GetContext(ctx)
 	p, ok := peer.FromContext(ctx)
 	if !ok {
-	    return ctx, status.Error(codes.Unauthenticated, "no peer found")
+		return ctx, status.Error(codes.Unauthenticated, "no peer found")
 	}
 	tlsAuth, ok := p.AuthInfo.(credentials.TLSInfo)
 	if !ok {
-	    return ctx, status.Error(codes.Unauthenticated, "unexpected peer transport credentials")
+		return ctx, status.Error(codes.Unauthenticated, "unexpected peer transport credentials")
 	}
 	if len(tlsAuth.State.VerifiedChains) == 0 || len(tlsAuth.State.VerifiedChains[0]) == 0 {
-	    return ctx, status.Error(codes.Unauthenticated, "could not verify peer certificate")
+		return ctx, status.Error(codes.Unauthenticated, "could not verify peer certificate")
 	}
 
 	var username string
-	
+
 	username = tlsAuth.State.VerifiedChains[0][0].Subject.CommonName
 
 	if len(username) == 0 {
 		return ctx, status.Error(codes.Unauthenticated, "invalid username in certificate common name.")
 	}
 
-	if err := PopulateAuthStruct(username, &rc.Auth); err != nil {
+	if err := PopulateAuthStruct(username, &rc.Auth, nil); err != nil {
 		glog.Infof("[%s] Failed to retrieve authentication information; %v", rc.ID, err)
-		return ctx, status.Errorf(codes.Unauthenticated, "")	
+		return ctx, status.Errorf(codes.Unauthenticated, "")
 	}
 
 	return ctx, nil

--- a/src/gnmi_server/jwtAuth.go
+++ b/src/gnmi_server/jwtAuth.go
@@ -1,43 +1,41 @@
-
 package gnmi_server
 
 import (
+	"common_utils"
+	"crypto/rand"
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/metadata"
-	"time"
-	jwt "github.com/dgrijalva/jwt-go"
-	"crypto/rand"
+	"google.golang.org/grpc/status"
 	spb "proto/gnoi"
-	"common_utils"
+	"time"
 )
 
 var (
-	JwtRefreshInt time.Duration
-	JwtValidInt   time.Duration
+	JwtRefreshInt    time.Duration
+	JwtValidInt      time.Duration
 	hmacSampleSecret = make([]byte, 16)
 )
+
 type Credentials struct {
 	Password string `json:"password"`
 	Username string `json:"username"`
 }
 
-
 type Claims struct {
-	Username string `json:"username"`
-	Roles []string `json:"roles"`
+	Username string   `json:"username"`
+	Roles    []string `json:"roles"`
 	jwt.StandardClaims
 }
-
-
 
 func generateJWT(username string, roles []string, expire_dt time.Time) string {
 	// Create a new token object, specifying signing method and the claims
 	// you would like it to contain.
 	claims := &Claims{
 		Username: username,
-		Roles: roles,
+		Roles:    roles,
 		StandardClaims: jwt.StandardClaims{
 			// In JWT, the expiry time is expressed as unix milliseconds
 			ExpiresAt: expire_dt.Unix(),
@@ -56,7 +54,7 @@ func GenerateJwtSecretKey() {
 
 func tokenResp(username string, roles []string) *spb.JwtToken {
 	exp_tm := time.Now().Add(JwtValidInt)
-	token := spb.JwtToken{AccessToken: generateJWT(username, roles, exp_tm), Type: "Bearer", ExpiresIn: int64(JwtValidInt/time.Second)}
+	token := spb.JwtToken{AccessToken: generateJWT(username, roles, exp_tm), Type: "Bearer", ExpiresIn: int64(JwtValidInt / time.Second)}
 	return &token
 }
 
@@ -68,10 +66,9 @@ func JwtAuthenAndAuthor(ctx context.Context) (*spb.JwtToken, context.Context, er
 		return nil, ctx, status.Errorf(codes.Unknown, "Invalid context")
 	}
 
-
 	if token_str, ok := md["access_token"]; ok {
 		token.AccessToken = token_str[0]
-	}else {
+	} else {
 		return nil, ctx, status.Errorf(codes.Unauthenticated, "No JWT Token Provided")
 	}
 
@@ -85,12 +82,10 @@ func JwtAuthenAndAuthor(ctx context.Context) (*spb.JwtToken, context.Context, er
 	if !tkn.Valid {
 		return &token, ctx, status.Errorf(codes.Unauthenticated, "Invalid JWT Token")
 	}
-	// if err := PopulateAuthStruct(claims.Username, &rc.Auth); err != nil {
-	// 	glog.Infof("[%s] Failed to retrieve authentication information; %v", rc.ID, err)
-	// 	return &token, ctx, status.Errorf(codes.Unauthenticated, "")	
-	// }
-	rc.Auth.User = claims.Username
-	rc.Auth.Roles = claims.Roles
+	if err := PopulateAuthStruct(claims.Username, &rc.Auth, claims.Roles); err != nil {
+		glog.Infof("[%s] Failed to retrieve authentication information; %v", rc.ID, err)
+		return &token, ctx, status.Errorf(codes.Unauthenticated, "")
+	}
+
 	return &token, ctx, nil
 }
-

--- a/src/gnmi_server/server.go
+++ b/src/gnmi_server/server.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"strings"
 	"sync"
-
+	"common_utils"
 	log "github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -162,11 +162,13 @@ func (srv *Server) Port() int64 {
 func authenticate(UserAuth AuthTypes, ctx context.Context) (context.Context,error) {
 	var err error
 	success := false
-
+	rc, ctx := common_utils.GetContext(ctx)
 	if !UserAuth.Any() {
 		//No Auth enabled
+		rc.Auth.AuthEnabled = false
 		return ctx, nil
 	}
+	rc.Auth.AuthEnabled = true
 	if UserAuth.Enabled("password") {
 		ctx, err = BasicAuthenAndAuthor(ctx)
 		if err == nil {

--- a/src/gnmi_server/server.go
+++ b/src/gnmi_server/server.go
@@ -189,7 +189,7 @@ func authenticate(UserAuth AuthTypes, ctx context.Context) (context.Context,erro
 	}
 
 	if !success {
-		return ctx,err
+		return ctx,status.Error(codes.Unauthenticated, "Unauthenticated")
 	} 
 
 	return ctx,nil


### PR DESCRIPTION
RBAC was not being enforced properly for JWT mode.
Fix formatting
Return proper unauthenticated response if authenticate fails.
Fix typo in gnmi_set command and add missing options.

Re-tested in these cases:
password,jwt enabled: Verified operator set fails with password and jwt auth, while admin succeeds.
None Auth Enabled: Set succeeds for both operator and admin since rbac is disabled
Client Cert Required with client_auth disabled: Set operation works with any valid certificate (rbac disabled)